### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+datasets
+torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+ffmpeg
+ffmpeg-python
+pydub
+evaluate
+nltk rouge-score datasets


### PR DESCRIPTION
Added Requirements.txt file. All the pip install should go to requirements.txt file and we should be executing 
pip install -r requirements.txt at the top of the notebook. We can also do a pip freeze and get all the supporting packages. This helps to avoid any unnecessary failures during demo.